### PR TITLE
space in attributes file path

### DIFF
--- a/syncronizer/src/org/ossnoize/git/fastimport/GitAttributes.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/GitAttributes.java
@@ -72,7 +72,7 @@ public class GitAttributes {
 	if (path == null || path.isEmpty())
       return path;
 	
-	String newPath = path.replace(" ", "[:space:]");
+	String newPath = path.replace(" ", "[[:space:]]");
 	return newPath;
   }
   public void addAttributeToPath(String path, GitAttributeKind ... allAttributes) {

--- a/syncronizer/src/org/ossnoize/git/fastimport/GitAttributes.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/GitAttributes.java
@@ -53,7 +53,8 @@ public class GitAttributes {
           }
           if(attrList.size() > 0)
           {
-            fileContent.put(line, attrList);
+        	String cleanLine = escapeSpace(line);
+            fileContent.put(cleanLine, attrList);
           }
         }
         line = parser.readLine();
@@ -67,13 +68,22 @@ public class GitAttributes {
     topComment = "#" + comment.replace("\n", "\n#");
   }
   
+  private String escapeSpace(String path) {
+	if (path == null || path.isEmpty())
+      return path;
+	
+	String newPath = path.replace(" ", "[:space:]");
+	return newPath;
+  }
   public void addAttributeToPath(String path, GitAttributeKind ... allAttributes) {
-    if(!fileContent.containsKey(path)) {
-      fileContent.put(path, new ArrayList<GitAttributeKind>());
+	String cleanPath = escapeSpace(path);
+	  
+    if(!fileContent.containsKey(cleanPath)) {
+      fileContent.put(cleanPath, new ArrayList<GitAttributeKind>());
     }
     ArrayList<GitAttributeKind> tempList = new ArrayList(Arrays.asList(allAttributes));
-    tempList.removeAll(fileContent.get(path));
-    fileContent.get(path).addAll(tempList);
+    tempList.removeAll(fileContent.get(cleanPath));
+    fileContent.get(cleanPath).addAll(tempList);
   }
   
   @Override
@@ -89,11 +99,13 @@ public class GitAttributes {
   }
 
   public void removePath(String path) {
-    fileContent.remove(path);
+	String cleanPath = escapeSpace(path);
+    fileContent.remove(cleanPath);
   }
 
   public boolean pathHasAttributes(String path) {
-    return fileContent.containsKey(path);
+	String cleanPath = escapeSpace(path);
+    return fileContent.containsKey(cleanPath);
   }
 
 }

--- a/syncronizer/test/org/sync/githelper/test/GitAttributesTest.java
+++ b/syncronizer/test/org/sync/githelper/test/GitAttributesTest.java
@@ -110,7 +110,7 @@ public class GitAttributesTest {
     assertEquals("# some comment that need to be kept\n"
         + "# which are multiline\n"
         + "path/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
-        + "path[:space:]with[:space:]spaces/file[:space:]withSpace.bin -text filter=lfs\n"
+        + "path[[:space:]]with[[:space:]]spaces/file[[:space:]]withSpace.bin -text filter=lfs\n"
         + "UnixScript.sh eol=lf\n"
         + "WindowsScript.bat eol=crlf",
         test.toString());

--- a/syncronizer/test/org/sync/githelper/test/GitAttributesTest.java
+++ b/syncronizer/test/org/sync/githelper/test/GitAttributesTest.java
@@ -35,7 +35,7 @@ public class GitAttributesTest {
     ByteArrayInputStream stream = new ByteArrayInputStream(
       ("# some comment that need to be kept\n"
         + "# which are multiline\n"
-        + "pa th/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
+        + "path/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
         + "UnixScript.sh eol=lf\n"
         + "WindowsScript.bat eol=crlf").getBytes());
     test.parse(stream);
@@ -60,7 +60,7 @@ public class GitAttributesTest {
   public void testPreservedAttributes() {
     assertEquals("# some comment that need to be kept\n"
         + "# which are multiline\n"
-        + "pa[:space:]th/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
+        + "path/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
         + "UnixScript.sh eol=lf\n"
         + "WindowsScript.bat eol=crlf",
       test.toString());
@@ -71,7 +71,7 @@ public class GitAttributesTest {
     test.addAttributeToPath("path/to/hugeFile.zip", GitAttributeKind.Binary, GitAttributeKind.FilterLfs, GitAttributeKind.DiffLfs, GitAttributeKind.MergeLfs);
     assertEquals("# some comment that need to be kept\n"
       + "# which are multiline\n"
-      + "pa[:space:]th/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
+      + "path/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
       + "path/to/hugeFile.zip -text filter=lfs diff=lfs merge=lfs\n"
       + "UnixScript.sh eol=lf\n"
       + "WindowsScript.bat eol=crlf",
@@ -80,10 +80,10 @@ public class GitAttributesTest {
   
   @Test
   public void testAddAttributesToExistingTrack() {
-    test.addAttributeToPath("pa th/to/file.bin", GitAttributeKind.Binary, GitAttributeKind.FilterLfs);
+    test.addAttributeToPath("path/to/file.bin", GitAttributeKind.Binary, GitAttributeKind.FilterLfs);
     assertEquals("# some comment that need to be kept\n"
         + "# which are multiline\n"
-        + "pa[:space:]th/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
+        + "path/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
         + "UnixScript.sh eol=lf\n"
         + "WindowsScript.bat eol=crlf", 
         test.toString());
@@ -91,7 +91,7 @@ public class GitAttributesTest {
   
   @Test
   public void testRemovePathAttributes() {
-    test.removePath("pa th/to/file.bin");
+    test.removePath("path/to/file.bin");
     assertEquals("# some comment that need to be kept\n"
       + "# which are multiline\n"
       + "UnixScript.sh eol=lf\n"
@@ -102,5 +102,17 @@ public class GitAttributesTest {
   @Test
   public void testIsPathPartOfAttributes() {
     assertEquals(true, test.pathHasAttributes("UnixScript.sh"));
+  }
+  
+  @Test
+  public void testEscapeSpace() {
+    test.addAttributeToPath("path with spaces/file withSpace.bin", GitAttributeKind.Binary, GitAttributeKind.FilterLfs);
+    assertEquals("# some comment that need to be kept\n"
+        + "# which are multiline\n"
+        + "path/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
+        + "path[:space:]with[:space:]spaces/file[:space:]withSpace.bin -text filter=lfs\n"
+        + "UnixScript.sh eol=lf\n"
+        + "WindowsScript.bat eol=crlf",
+        test.toString());
   }
 }

--- a/syncronizer/test/org/sync/githelper/test/GitAttributesTest.java
+++ b/syncronizer/test/org/sync/githelper/test/GitAttributesTest.java
@@ -35,7 +35,7 @@ public class GitAttributesTest {
     ByteArrayInputStream stream = new ByteArrayInputStream(
       ("# some comment that need to be kept\n"
         + "# which are multiline\n"
-        + "path/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
+        + "pa th/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
         + "UnixScript.sh eol=lf\n"
         + "WindowsScript.bat eol=crlf").getBytes());
     test.parse(stream);
@@ -60,7 +60,7 @@ public class GitAttributesTest {
   public void testPreservedAttributes() {
     assertEquals("# some comment that need to be kept\n"
         + "# which are multiline\n"
-        + "path/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
+        + "pa[:space:]th/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
         + "UnixScript.sh eol=lf\n"
         + "WindowsScript.bat eol=crlf",
       test.toString());
@@ -71,7 +71,7 @@ public class GitAttributesTest {
     test.addAttributeToPath("path/to/hugeFile.zip", GitAttributeKind.Binary, GitAttributeKind.FilterLfs, GitAttributeKind.DiffLfs, GitAttributeKind.MergeLfs);
     assertEquals("# some comment that need to be kept\n"
       + "# which are multiline\n"
-      + "path/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
+      + "pa[:space:]th/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
       + "path/to/hugeFile.zip -text filter=lfs diff=lfs merge=lfs\n"
       + "UnixScript.sh eol=lf\n"
       + "WindowsScript.bat eol=crlf",
@@ -80,10 +80,10 @@ public class GitAttributesTest {
   
   @Test
   public void testAddAttributesToExistingTrack() {
-    test.addAttributeToPath("path/to/file.bin", GitAttributeKind.Binary, GitAttributeKind.FilterLfs);
+    test.addAttributeToPath("pa th/to/file.bin", GitAttributeKind.Binary, GitAttributeKind.FilterLfs);
     assertEquals("# some comment that need to be kept\n"
         + "# which are multiline\n"
-        + "path/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
+        + "pa[:space:]th/to/file.bin filter=lfs diff=lfs merge=lfs -text\n"
         + "UnixScript.sh eol=lf\n"
         + "WindowsScript.bat eol=crlf", 
         test.toString());
@@ -91,7 +91,7 @@ public class GitAttributesTest {
   
   @Test
   public void testRemovePathAttributes() {
-    test.removePath("path/to/file.bin");
+    test.removePath("pa th/to/file.bin");
     assertEquals("# some comment that need to be kept\n"
       + "# which are multiline\n"
       + "UnixScript.sh eol=lf\n"


### PR DESCRIPTION
Added support for space in attribute file paths. Spaces are now replaced
by [:space:].
Tests changed accordingly.