### PR TITLE
Support external file providing mapping of users to email addresses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ These options must be set for all runs:
 * `-P <port>` StarTeam server port
 * `-p <project>` StarTeam project
 * `-v <view>` StarTeam view
-* `-d <domain>` Email domain to append to StarTeam user names
 
 ### Import Modes
 
@@ -75,6 +74,14 @@ All four modes can:
 * Automatically create the Git repository (as a bare repo) with the `-c` option.
 * Expand StarTeam keywords with the `-k` option.
 * Select the StarTeam user and password with the `-U <user>` and `--password` options.
+* Specify a file containing a mapping of user names to emails with `-m <mailMappingFile>`.
+  This mapping will be used in case the user performing the conversion does not have the
+  required administrator access to extract email addresses from the StarTeam server.
+* Specify the domain to append to StarTeam user names with `-d <domain>`. This mapping will
+  be used in case the user performing the conversion does not have the
+  required administrator access to extract email addresses from the StarTeam server, and
+  an explicit mapping cannot be found in the mail mapping file if one is provided 
+  with the `-m <mailMappingFile>` command line option.
 
 The first three modes can:
 
@@ -191,6 +198,20 @@ Examples
               -W $REPO \
               --verbose &
         ) >vlc2android-all.log 2>&1 </dev/null
+
+### Add mapping of user names to actual email address
+
+In case the user performing the conversion does not have StarTeam user account admin access,
+the emails can be specified using a mapping file as follow:
+
+1.  Create mapping file:
+
+          echo "John Smith = jsmith@acme.com"               >  mailmap
+          echo "J. Random Hacker = jrhacker@hackersoft.com" >> mailmap
+          ...
+          
+2.  Execute importation with additional `-m <mailmap>` command line option. If the `-d <domain>` is
+    also provided, users which are not found in `mailmap` will get an email using the default domain provided. 
 
 ### Latest Revisions Mode
 

--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
     <property name="jargs.jar" value="${basedir}/lib/jargs.jar"/>
     <property name="junit.jar" value="/usr/share/java/junit.jar:/usr/share/java/junit4.jar:${basedir}/lib/junit-4.12.jar"/>
     <property name="starteam.jar" value="starteam110.jar"/>
-    <property name="hamcrest.jar" value="/usr/share/java/hamcrest/core.jar:${basedir}/lib/hamcrest-core-1.3.jar"/>
+    <property name="hamcrest.jar" value="${basedir}/lib/hamcrest-core-1.3.jar:/usr/share/java/hamcrest/core.jar"/>
   </target>
 
   <target name="clean">

--- a/fake-starteam/src/com/starbase/starteam/GroupAccount.java
+++ b/fake-starteam/src/com/starbase/starteam/GroupAccount.java
@@ -7,7 +7,7 @@
  * The implementation is given AS-IS and should not be considered a reference 
  * to the API. The behavior on a lots of method and class will not be the
  * same as the real API. The reproduction only seek to mimic some basic 
- * operation. You will not find anything here that can be deduced by using
+ * operation. You will not found anything here that can be deduced by using
  * the real API.
  * 
  * Fake-Starteam is distributed in the hope that it will be useful,
@@ -16,25 +16,20 @@
  *****************************************************************************/
 package com.starbase.starteam;
 
-import org.ossnoize.fakestarteam.SerializableUser;
-import org.ossnoize.fakestarteam.UserAccountProvider;
-import org.ossnoize.fakestarteam.UserProvider;
+public class GroupAccount extends CacheRef {
 
-public class ServerAdministration
-{
-  public UserAccount findUserAccount(int paramInt)
-  {
-		UserAccount account = UserAccountProvider.getInstance().getUserAccount(UserProvider.getInstance().getUser(paramInt).getID());
-		if (null != account) {
-			GroupAccount[] groups = account.getGroupAccounts();
-			for (GroupAccount group : groups) {
-				if (group.hasPermission(Permission.SERVER_ADMIN_USER_ACCOUNTS)) {
-					return account;
-				}
-			}
-			throw new ServerException();
-		}
-		return account;
+	private int permissionFlags;
+	
+	public void addPermission(int permission) {
+		permissionFlags |= permission;
+	}
+	
+	public boolean hasPermission(int permission) {
+		return ((permissionFlags & permission) != 0);  
+	}
 
-  }
+	public void removePermission(int permission) {
+		permissionFlags &= ~permission;
+	}
+	
 }

--- a/fake-starteam/src/com/starbase/starteam/Permission.java
+++ b/fake-starteam/src/com/starbase/starteam/Permission.java
@@ -7,7 +7,7 @@
  * The implementation is given AS-IS and should not be considered a reference 
  * to the API. The behavior on a lots of method and class will not be the
  * same as the real API. The reproduction only seek to mimic some basic 
- * operation. You will not find anything here that can be deduced by using
+ * operation. You will not found anything here that can be deduced by using
  * the real API.
  * 
  * Fake-Starteam is distributed in the hope that it will be useful,
@@ -16,25 +16,7 @@
  *****************************************************************************/
 package com.starbase.starteam;
 
-import org.ossnoize.fakestarteam.SerializableUser;
-import org.ossnoize.fakestarteam.UserAccountProvider;
-import org.ossnoize.fakestarteam.UserProvider;
+public interface Permission {
 
-public class ServerAdministration
-{
-  public UserAccount findUserAccount(int paramInt)
-  {
-		UserAccount account = UserAccountProvider.getInstance().getUserAccount(UserProvider.getInstance().getUser(paramInt).getID());
-		if (null != account) {
-			GroupAccount[] groups = account.getGroupAccounts();
-			for (GroupAccount group : groups) {
-				if (group.hasPermission(Permission.SERVER_ADMIN_USER_ACCOUNTS)) {
-					return account;
-				}
-			}
-			throw new ServerException();
-		}
-		return account;
-
-  }
+	public static final int SERVER_ADMIN_USER_ACCOUNTS = 134217728; 
 }

--- a/fake-starteam/src/com/starbase/starteam/UserAccount.java
+++ b/fake-starteam/src/com/starbase/starteam/UserAccount.java
@@ -17,18 +17,30 @@
 package com.starbase.starteam;
 
 import org.ossnoize.fakestarteam.SerializableUser;
+import org.ossnoize.fakestarteam.UserProvider;
 
 public class UserAccount extends CacheRef
 {
 	private SerializableUser aUser;
+	private GroupAccount[]   aGroup;
 	public UserAccount(Server server) {
 		aUser = null;
+		aGroup = new GroupAccount[1];
+		aGroup[0] = new GroupAccount();
+	}
+
+	public UserAccount(int uid) {
+		aUser = (SerializableUser) UserProvider.getInstance().getUser(uid);
+		aGroup = new GroupAccount[1];
+		aGroup[0] = new GroupAccount();
 	}
 
 	protected UserAccount(SerializableUser internal) {
 		aUser = internal;
+		aGroup = new GroupAccount[1];
+		aGroup[0] = new GroupAccount();
 	}
-
+	
   public String getName()
   {
 		return aUser.getName();
@@ -37,6 +49,11 @@ public class UserAccount extends CacheRef
   public String getEmailAddress()
   {
 		return aUser.getEMail();
+  }
+  
+  public GroupAccount[] getGroupAccounts()
+  {
+	  return aGroup;
   }
 
 }

--- a/fake-starteam/src/com/starbase/starteam/UserAccount.java
+++ b/fake-starteam/src/com/starbase/starteam/UserAccount.java
@@ -29,7 +29,7 @@ public class UserAccount extends CacheRef
 		aGroup[0] = new GroupAccount();
 	}
 
-	public UserAccount(int uid) {
+	protected UserAccount(int uid) {
 		aUser = (SerializableUser) UserProvider.getInstance().getUser(uid);
 		aGroup = new GroupAccount[1];
 		aGroup[0] = new GroupAccount();

--- a/fake-starteam/src/org/ossnoize/fakestarteam/FakeUserAccount.java
+++ b/fake-starteam/src/org/ossnoize/fakestarteam/FakeUserAccount.java
@@ -16,50 +16,22 @@
  *****************************************************************************/
 package org.ossnoize.fakestarteam;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
 
+import org.ossnoize.fakestarteam.exception.ObjectIdNotFoundError;
+
+import com.starbase.starteam.Folder;
+import com.starbase.starteam.Item;
 import com.starbase.starteam.UserAccount;
+import com.starbase.starteam.View;
 
-public class UserAccountProvider {
-
-	private static UserAccountProvider Reference = null;
+public class FakeUserAccount extends UserAccount {
 	
-	public static UserAccountProvider getInstance() {
-		if(Reference == null) {
-			Reference = new UserAccountProvider();
-		}
-		return Reference;
-	}
-	
-	public static void deleteInstance() {
-		Reference = null;
-	}
-	
-	private Map<Integer, UserAccount> accounts = new HashMap<Integer, UserAccount>();
-	
-	private UserAccountProvider() {
-	}
-	
-
-	public void addUserAccount(Integer uid) {
-		if (accounts.containsKey(uid)) {
-			throw new Error("Duplicate user id " + uid);
-		}
-		accounts.put(uid, new FakeUserAccount(uid));
-	}
-	
-	public boolean deleteUserAccount(int id) {
-		if (accounts.containsKey(id)) {
-			accounts.remove(id);
-			return true;
-		}
-		return false;
-	}
-
-	public UserAccount getUserAccount(Integer uid) {
-		if(null == uid)
-			return null;
-		return accounts.get(uid);
-	}
+	public FakeUserAccount(int uid) {
+		super(uid);
+	}	
 }

--- a/fake-starteam/src/org/ossnoize/fakestarteam/UserAccountProvider.java
+++ b/fake-starteam/src/org/ossnoize/fakestarteam/UserAccountProvider.java
@@ -1,0 +1,65 @@
+/*****************************************************************************
+ * All public interface based on Starteam API are a property of Borland, 
+ * those interface are reproduced here only for testing purpose. You should
+ * never use those interface to create a competitive product to the Starteam
+ * Server. 
+ * 
+ * The implementation is given AS-IS and should not be considered a reference 
+ * to the API. The behavior on a lots of method and class will not be the
+ * same as the real API. The reproduction only seek to mimic some basic 
+ * operation. You will not found anything here that can be deduced by using
+ * the real API.
+ * 
+ * Fake-Starteam is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *****************************************************************************/
+package org.ossnoize.fakestarteam;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.starbase.starteam.UserAccount;
+
+public class UserAccountProvider {
+
+	private static UserAccountProvider Reference = null;
+	
+	public static UserAccountProvider getInstance() {
+		if(Reference == null) {
+			Reference = new UserAccountProvider();
+		}
+		return Reference;
+	}
+	
+	public static void deleteInstance() {
+		Reference = null;
+	}
+	
+	private Map<Integer, UserAccount> accounts = new HashMap<Integer, UserAccount>();
+	
+	private UserAccountProvider() {
+	}
+	
+
+	public void addUserAccount(Integer uid) {
+		if (accounts.containsKey(uid)) {
+			throw new Error("Duplicate user id " + uid);
+		}
+		accounts.put(uid, new UserAccount(uid));
+	}
+	
+	public boolean deleteUserAccount(int id) {
+		if (accounts.containsKey(id)) {
+			accounts.remove(id);
+			return true;
+		}
+		return false;
+	}
+
+	public UserAccount getUserAccount(Integer uid) {
+		if(null == uid)
+			return null;
+		return accounts.get(uid);
+	}
+}

--- a/fake-starteam/src/org/ossnoize/fakestarteam/UserProvider.java
+++ b/fake-starteam/src/org/ossnoize/fakestarteam/UserProvider.java
@@ -66,6 +66,10 @@ public class UserProvider {
 			if(userFile.exists()) {
 				in = new ObjectInputStream(new FileInputStream(userFile));
 				users = (Map<Integer, SerializableUser>) in.readObject();
+
+				for(Entry<Integer, SerializableUser> user : users.entrySet()) {
+					UserAccountProvider.getInstance().addUserAccount(user.getKey());
+				}
 			}
 		} catch (IOException e) {
 			e.printStackTrace();
@@ -111,6 +115,7 @@ public class UserProvider {
 			lastUserID = Collections.max(users.keySet()) + 1;
 		}
 		users.put(lastUserID, new SerializableUser(uid, lastUserID));
+		UserAccountProvider.getInstance().addUserAccount(users.get(lastUserID).getID());
 		writeUserList();
 	}
 	

--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -90,6 +90,7 @@ public class GitImporter {
 	private Map<String, DataRef> tagMarks = new HashMap<String, DataRef>();
 	// email domain to use
 	private String domain;
+	private UserMapping userMapping;
 	private long lfsMinimumSize = Long.MAX_VALUE;
 	private Pattern lfsRegex;
 	private CommitPopulationStrategy CheckoutStrategy;
@@ -148,6 +149,16 @@ public class GitImporter {
 
 	public void setDomain(String domain) {
 		this.domain = domain;
+		if (this.userMapping != null) {
+			this.userMapping.setDefaultDomain(this.domain);
+		}
+	}
+
+	public void setUserMapping(UserMapping userDirectory) {
+		this.userMapping = userDirectory;
+		if (this.userMapping != null) {
+			this.userMapping.setDefaultDomain(this.domain);
+		}
 	}
 
 	private boolean dontTryServerAdministrationAgain = false;
@@ -213,7 +224,7 @@ public class GitImporter {
 			if (dontTryServerAdministrationAgain) {
 				User userAccount = server.getUser(current.getUid());
 				userName = userAccount.getName();
-				userEmail = userName.replaceAll(" ", ".") + "@" + domain;
+				userEmail = userMapping.getEmail(userName);
 			}
 			String path = current.getPath();
 

--- a/syncronizer/src/org/sync/MainEntry.java
+++ b/syncronizer/src/org/sync/MainEntry.java
@@ -60,6 +60,7 @@ public class MainEntry {
 		CmdLineParser.Option selectTime = parser.addStringOption('t', "time");
 		CmdLineParser.Option selectFolder = parser.addStringOption('f', "folder");
 		CmdLineParser.Option selectDomain = parser.addStringOption('d', "domain");
+		CmdLineParser.Option mailMap = parser.addStringOption('m', "mailmap");
 		CmdLineParser.Option isExpandKeywords = parser.addBooleanOption('k', "keyword");
 		CmdLineParser.Option selectUser = parser.addStringOption('U', "user");
 		CmdLineParser.Option isResume = parser.addBooleanOption('R', "resume");
@@ -107,6 +108,7 @@ public class MainEntry {
 		Boolean revisionLabelBased = (Boolean) parser.getOptionValue(selectRevisionLabelBasedImport);
 		String folder = (String) parser.getOptionValue(selectFolder);
 		String domain = (String) parser.getOptionValue(selectDomain);
+		String mailMapFilename = (String) parser.getOptionValue(mailMap);
 		Boolean keyword = (Boolean) parser.getOptionValue(isExpandKeywords);
 		String user = (String) parser.getOptionValue(selectUser);
 		Boolean resume = (Boolean) parser.getOptionValue(isResume);
@@ -277,6 +279,7 @@ public class MainEntry {
 						importer.setVerbose(verbose);
 						importer.setCreateCheckpoints(createCheckpoints);
 						importer.setDomain(domain);
+						importer.setUserMapping(new UserMapping(mailMapFilename));
 						importer.setMinimumLFSSize(startTrackingAtSize);
 						importer.setLFSPattern(lfsRegexPattern);
 						importer.setLabelExclusion(excludedLabels);
@@ -340,7 +343,8 @@ public class MainEntry {
 		System.out.println("-p <project>\t\tSelect the project to import from");
 		System.out.println("-v <view>\t\tSelect the view used for importation");
 		System.out.println("-A\t\tImport all views");
-		System.out.println("-d <domain>\t\tSelect the email domain (format like gmail.com) of the user");
+		System.out.println("[-d <domain>]\t\tSelect the email domain (format like gmail.com) of the user");
+		System.out.println("[-m <mailmap>]\t\tSelect the file which defines the user email mapping (format like user = user@gmail.com)");
 		System.out.println("[-t <time>]\t\tSelect the time (format like \"2012-07-11 23:59:59\") to import from");
 		System.out.println("[-f <folder regex>]\t\tSelect the folder (in Java regex format) to import from");
 		System.out.println("[-T]\t\t\tDo a day by day importation of the starteam view");

--- a/syncronizer/src/org/sync/UserMapping.java
+++ b/syncronizer/src/org/sync/UserMapping.java
@@ -1,0 +1,124 @@
+/*****************************************************************************
+    This file is part of Git-Starteam.
+
+    Git-Starteam is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Git-Starteam is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Git-Starteam.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package org.sync;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class UserMapping {
+
+	private Map<String, String> mapping;
+	private String              defaultDomain;
+	
+	public UserMapping(String filename) {
+		this.mapping = new HashMap<String,String>();
+		if (filename != null) {
+			parseDirectory(filename);
+		}
+	}
+	protected UserMapping(InputStream stream) {
+		this.mapping = new HashMap<String,String>();
+		if (stream != null) {
+		  parseDirectory(stream);
+		}
+	}
+	
+	public void setDefaultDomain(String domain) {
+		this.defaultDomain = domain;
+	}
+	
+	public String getEmail(String name) {
+		String email = mapping.get(name);
+		if (null == email) {
+			
+			if (defaultDomain != null) {
+				email = name.replaceAll("\\.", "").replaceAll(" ", ".") + "@" + defaultDomain;
+			}
+			else {
+				email = "unknown@noreply.com";
+			}
+		}
+		return email;
+	}
+	
+	
+	private void parseDirectory(InputStream stream) {
+		String line;
+		try (
+			InputStreamReader streamReader = new InputStreamReader(stream, Charset.forName("UTF-8"));
+		    BufferedReader reader = new BufferedReader(streamReader);
+		) {
+			Pattern commentPattern = Pattern.compile("^([^#]*)#.*");
+			Pattern emailPattern = Pattern.compile("^([^=]*)=\\s*([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})\\s*");
+			Pattern emptyPattern = Pattern.compile("^\\s*$");
+			
+			int lineno = 0;
+		    while ((line = reader.readLine()) != null) {
+		    	++lineno;
+		    	Matcher commentMatcher = commentPattern.matcher(line);
+		    	if (commentMatcher.matches()) {
+		    		line = commentMatcher.group(1);
+		    	}
+		    	Matcher emailMatcher = emailPattern.matcher(line);
+		    	if (emailMatcher.matches()) {
+		    		String key   = emailMatcher.group(1).trim();
+		    		String email = emailMatcher.group(2).trim();
+		    		this.mapping.put(key, email);
+		    	}
+		    	else {
+		    		Matcher emptyMatcher = emptyPattern.matcher(line);
+		    		if (!emptyMatcher.matches()) {
+		    			Log.log("Invalid email mapping at line " + lineno + ": " + line);
+		    		}
+		    	}
+		    }
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			Log.log("Error parsing mapping: " + e.getMessage());
+		}
+	}
+	
+	private void dump() {
+		System.out.println("UserMapping dump:");
+		for (Entry<String, String> entry : mapping.entrySet()) {
+			System.out.println("  " + entry.getKey() + " => " + entry.getValue());
+		}
+	}
+	
+	private void parseDirectory(String filename) {
+		try (
+		    InputStream stream = new FileInputStream(filename);
+		) {
+			parseDirectory(stream);
+		} catch (FileNotFoundException e) {
+			Log.log("Email mapping file \"" + filename + "\" not found.");
+		} catch (IOException e) {
+			Log.log("Error opening mapping file \"" + filename + "\": " + e.getMessage());
+		}
+	}
+}

--- a/syncronizer/src/org/sync/UserMapping.java
+++ b/syncronizer/src/org/sync/UserMapping.java
@@ -72,8 +72,10 @@ public class UserMapping {
 			InputStreamReader streamReader = new InputStreamReader(stream, Charset.forName("UTF-8"));
 		    BufferedReader reader = new BufferedReader(streamReader);
 		) {
-			Pattern commentPattern = Pattern.compile("^([^#]*)#.*");
-			Pattern emailPattern = Pattern.compile("^([^=]*)=\\s*([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})\\s*");
+			Pattern commentPattern = Pattern.compile("^\\s*#.*");
+			// From http://emailregex.com/ (with required escaping to be a valid string literal) 
+			String  emailPart    = "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])";
+			Pattern emailPattern = Pattern.compile("^([^=]*)=\\s*(" + emailPart + ")\\s*");
 			Pattern emptyPattern = Pattern.compile("^\\s*$");
 			
 			int lineno = 0;
@@ -81,7 +83,7 @@ public class UserMapping {
 		    	++lineno;
 		    	Matcher commentMatcher = commentPattern.matcher(line);
 		    	if (commentMatcher.matches()) {
-		    		line = commentMatcher.group(1);
+		    		continue;
 		    	}
 		    	Matcher emailMatcher = emailPattern.matcher(line);
 		    	if (emailMatcher.matches()) {
@@ -97,8 +99,6 @@ public class UserMapping {
 		    	}
 		    }
 		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
 			Log.log("Error parsing mapping: " + e.getMessage());
 		}
 	}

--- a/syncronizer/test/org/sync/test/MainEntryTest.java
+++ b/syncronizer/test/org/sync/test/MainEntryTest.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Iterator;
@@ -19,6 +20,7 @@ import org.junit.Test;
 import org.ossnoize.fakestarteam.InternalPropertiesProvider;
 import org.ossnoize.fakestarteam.ProjectProvider;
 import org.ossnoize.fakestarteam.SimpleTypedResourceIDProvider;
+import org.ossnoize.fakestarteam.UserAccountProvider;
 import org.ossnoize.fakestarteam.UserProvider;
 import org.ossnoize.fakestarteam.builder.StarteamProjectBuilder;
 import org.ossnoize.git.fastimport.GitAttributes;
@@ -45,6 +47,7 @@ public class MainEntryTest {
 		FileUtility.rmDir(importLocation);
 		SimpleTypedResourceIDProvider.deleteProvider();
 		UserProvider.deleteInstance();
+		UserAccountProvider.deleteInstance();
 		InternalPropertiesProvider.deleteInstace();
 		ProjectProvider.deleteInstance();
 		RepositoryHelperFactory.deleteFactory();
@@ -88,6 +91,55 @@ public class MainEntryTest {
 		assertFalse(i.hasNext());
     String repoInformation = importLocation.getAbsolutePath() + File.separator + "starteam" + File.separator + "StarteamFileInfo.gz";
     assertTrue(new File(repoInformation).exists());
+	}
+
+	@Test
+	public void testLabelImportRemappedEmail() throws IOException {
+		final String username  = "Test";
+		final String email     = "j.random.hacker@acme.com";
+		String newAuthor = username + " <" + email + ">";
+		
+		String mailMapFilename = Files.createTempFile("mailmap", null).toString();
+		try(  PrintWriter out = new PrintWriter( mailMapFilename )  ) {
+		    out.println( username + " = " + email);
+		}
+		
+		StarteamProjectBuilder.main(new String[] {"UnitTest", "1", "10"});		
+		MainEntry.main(new String[] {
+				"-h", "localhost", "-P", "23456", "-U", username, "--password=passw0rd", "-p", "UnitTest", "-v", "MAIN",
+				"-d", "test.com", "-m", mailMapFilename, "-c", "-L", "-W", importLocation.getAbsolutePath(), "--verbose"
+				});
+
+		RepositoryHelperFactory.getFactory().setCreateRepo(false);
+		RepositoryHelper helper = RepositoryHelperFactory.getFactory().createHelper();
+		
+		List<LogEntry> entries = helper.getCommitLog(new SmallRef("MAIN"));
+		Collections.reverse(entries);
+		Iterator<LogEntry> i = entries.iterator();
+		
+		assertCommit01(i.next(), newAuthor);
+		assertCommit02(i.next(), newAuthor);
+		assertCommit03(i.next(), newAuthor);
+		assertCommit04(i.next(), newAuthor);
+		assertCommit05(i.next(), newAuthor);
+		assertCommit06(i.next(), newAuthor);
+		assertCommit07(i.next(), newAuthor);
+		assertCommit08(i.next(), newAuthor);
+		assertCommit09(i.next(), newAuthor);
+		assertCommit10(i.next(), newAuthor);
+		assertCommit11(i.next(), newAuthor);
+		assertCommit12(i.next(), newAuthor);
+		assertCommit13(i.next(), newAuthor);
+		assertCommit14(i.next(), newAuthor);
+		assertCommit15(i.next(), newAuthor);
+		assertCommit16(i.next(), newAuthor);
+		assertCommit17(i.next(), newAuthor);
+		assertCommit18(i.next(), newAuthor);
+		assertCommit19(i.next(), newAuthor);
+		assertCommit20(i.next(), newAuthor);
+		assertFalse(i.hasNext());
+        String repoInformation = importLocation.getAbsolutePath() + File.separator + "starteam" + File.separator + "StarteamFileInfo.gz";
+        assertTrue(new File(repoInformation).exists());
 	}
 	
 	@Test
@@ -416,6 +468,10 @@ public class MainEntryTest {
   }
   
 	private void assertCommit20(LogEntry entry) {
+		assertCommit20(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit20(LogEntry entry, String author) {
 		int index;
 		assertEquals("Load from history and Return it",        entry.getComment());
 		assertEquals(1,                                        entry.getFilesEntry().size());
@@ -424,10 +480,14 @@ public class MainEntryTest {
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getFromType());
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getToType());
 		assertEquals(LogEntry.TypeOfModification.Modification, entry.getFilesEntry().get(index).getTypeOfModification());
-		assertEquals("Test <Test@test.com>",                   entry.getAuthor());
+		assertEquals(author,                                   entry.getAuthor());
 	}
 
 	private void assertCommit19(LogEntry entry) {
+		assertCommit19(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit19(LogEntry entry, String author) {
 		int index;
 		assertEquals("Improve Logic of project creation",      entry.getComment());
 		assertEquals(1,                                        entry.getFilesEntry().size());
@@ -436,10 +496,14 @@ public class MainEntryTest {
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getFromType());
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getToType());
 		assertEquals(LogEntry.TypeOfModification.Modification, entry.getFilesEntry().get(index).getTypeOfModification());
-		assertEquals("Test <Test@test.com>",                   entry.getAuthor());
+		assertEquals(author,                                   entry.getAuthor());
 	}
 
 	private void assertCommit18(LogEntry entry) {
+		assertCommit18(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit18(LogEntry entry, String author) {
 		int index;
 		assertEquals("Class reprensenting the view of starteam",
 				                                               entry.getComment());
@@ -449,10 +513,14 @@ public class MainEntryTest {
 		assertEquals(GitFileType.NullFile,                     entry.getFilesEntry().get(index).getFromType());
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getToType());
 		assertEquals(LogEntry.TypeOfModification.Addition,     entry.getFilesEntry().get(index).getTypeOfModification());
-		assertEquals("Test <Test@test.com>",                   entry.getAuthor());
+		assertEquals(author,                                   entry.getAuthor());
 	}
 
 	private void assertCommit17(LogEntry entry) {
+		assertCommit17(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit17(LogEntry entry, String author) {
 		int index;
 		assertEquals("Added subfolder listing capacity",       entry.getComment());
 		assertEquals(1,                                        entry.getFilesEntry().size());
@@ -461,10 +529,14 @@ public class MainEntryTest {
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getFromType());
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getToType());
 		assertEquals(LogEntry.TypeOfModification.Modification, entry.getFilesEntry().get(index).getTypeOfModification());
-		assertEquals("Test <Test@test.com>",                   entry.getAuthor());
+		assertEquals(author,                                   entry.getAuthor());
 	}
 
 	private void assertCommit16(LogEntry entry) {
+		assertCommit16(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit16(LogEntry entry, String author) {
 		int index;
 		assertEquals("Added getParentFolder property",         entry.getComment());
 		assertEquals(1,                                        entry.getFilesEntry().size());
@@ -473,10 +545,14 @@ public class MainEntryTest {
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getFromType());
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getToType());
 		assertEquals(LogEntry.TypeOfModification.Modification, entry.getFilesEntry().get(index).getTypeOfModification());
-		assertEquals("Test <Test@test.com>",                   entry.getAuthor());
+		assertEquals(author,                                   entry.getAuthor());
 	}
 
 	private void assertCommit15(LogEntry entry) {
+		assertCommit15(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit15(LogEntry entry, String author) {
 		int index = 0;
 		assertEquals("",                                       entry.getComment());
 		assertEquals(1,                                        entry.getFilesEntry().size());
@@ -484,10 +560,14 @@ public class MainEntryTest {
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getFromType());
 		assertEquals(GitFileType.NullFile,                     entry.getFilesEntry().get(index).getToType());
 		assertEquals(LogEntry.TypeOfModification.Delete,       entry.getFilesEntry().get(index).getTypeOfModification());
-		assertEquals("Test <Test@test.com>",                   entry.getAuthor());
+		assertEquals(author,                                   entry.getAuthor());
 	}
 
 	private void assertCommit14(LogEntry entry) {
+		assertCommit14(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit14(LogEntry entry, String author) {
 		int index;
 		assertEquals("Fixed stream-off size definition",       entry.getComment());
 		assertEquals(2,                                        entry.getFilesEntry().size());
@@ -501,10 +581,14 @@ public class MainEntryTest {
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getFromType());
 		assertEquals(GitFileType.Normal,                       entry.getFilesEntry().get(index).getToType());
 		assertEquals(LogEntry.TypeOfModification.Modification, entry.getFilesEntry().get(index).getTypeOfModification());
-		assertEquals("Test <Test@test.com>",                   entry.getAuthor());
+		assertEquals(author,                                   entry.getAuthor());
 	}
 
 	private void assertCommit13(LogEntry entry) {
+		assertCommit13(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit13(LogEntry entry, String author) {
 		assertEquals("Unexpected Move", entry.getComment());
 		assertEquals(11,                                  entry.getFilesEntry().size());
 		int index = 0;
@@ -585,10 +669,14 @@ public class MainEntryTest {
 		assertEquals(LogEntry.TypeOfModification.Rename,  entry.getFilesEntry().get(index).getTypeOfModification());
 		assertEquals(100,                                 entry.getFilesEntry().get(index).getDiffRatio());
 		index++;
-		assertEquals("Test <Test@test.com>",              entry.getAuthor());
+		assertEquals(author,                              entry.getAuthor());
 	}
 
 	private void assertCommit12(LogEntry entry) {
+		assertCommit12(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit12(LogEntry entry, String author) {
 		assertEquals("Copy files from msvcp90", entry.getComment());
 		assertEquals(10, entry.getFilesEntry().size());
 		assertEquals("src/cpp/wine/msvcp100/Makefile.in", entry.getFilesEntry().get(0).getPath());
@@ -631,37 +719,49 @@ public class MainEntryTest {
 		assertEquals(GitFileType.NullFile, entry.getFilesEntry().get(9).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(9).getToType());
 		assertEquals(LogEntry.TypeOfModification.Addition, entry.getFilesEntry().get(9).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
 
 	private void assertCommit11(LogEntry entry) {
+		assertCommit11(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit11(LogEntry entry, String author) {
 		assertEquals("Stub of msvcp100 dlls", entry.getComment());
 		assertEquals(1, entry.getFilesEntry().size());
 		assertEquals("src/cpp/wine/msvcp100/msvcp100.c", entry.getFilesEntry().get(0).getPath());
 		assertEquals(GitFileType.NullFile, entry.getFilesEntry().get(0).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(0).getToType());
 		assertEquals(LogEntry.TypeOfModification.Addition, entry.getFilesEntry().get(0).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
 
 	private void assertCommit10(LogEntry entry) {
+		assertCommit10(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit10(LogEntry entry, String author) {
 		assertEquals("Basic construction file", entry.getComment());
 		assertEquals(1, entry.getFilesEntry().size());
 		assertEquals("src/cpp/wine/msvcp100/Makefile.in", entry.getFilesEntry().get(0).getPath());
 		assertEquals(GitFileType.NullFile, entry.getFilesEntry().get(0).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(0).getToType());
 		assertEquals(LogEntry.TypeOfModification.Addition, entry.getFilesEntry().get(0).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
 
 	private void assertCommit09(LogEntry entry) {
+		assertCommit09(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit09(LogEntry entry, String author) {
 		assertEquals("Updated lexer", entry.getComment());
 		assertEquals(1, entry.getFilesEntry().size());
 		assertEquals("src/cpp/mesa/glsl/glsl_lexer.ll", entry.getFilesEntry().get(0).getPath());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(0).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(0).getToType());
 		assertEquals(LogEntry.TypeOfModification.Modification, entry.getFilesEntry().get(0).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
   
 	private void assertCommit09Alt(LogEntry entry) {
@@ -675,16 +775,24 @@ public class MainEntryTest {
 	}
 
 	private void assertCommit08(LogEntry entry) {
+		assertCommit08(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit08(LogEntry entry, String author) {
 		assertEquals("Parser should always be with lexer", entry.getComment());
 		assertEquals(1, entry.getFilesEntry().size());
 		assertEquals("src/cpp/mesa/glsl/glsl_parser.yy", entry.getFilesEntry().get(0).getPath());
 		assertEquals(GitFileType.NullFile, entry.getFilesEntry().get(0).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(0).getToType());
 		assertEquals(LogEntry.TypeOfModification.Addition, entry.getFilesEntry().get(0).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
 
 	private void assertCommit07(LogEntry entry) {
+		assertCommit07(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit07(LogEntry entry, String author) {
 		assertEquals("Upgrade the version", entry.getComment());
 		assertEquals(3, entry.getFilesEntry().size());
 		assertEquals("src/java/starteam/File.java", entry.getFilesEntry().get(0).getPath());
@@ -699,7 +807,7 @@ public class MainEntryTest {
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(2).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(2).getToType());
 		assertEquals(LogEntry.TypeOfModification.Modification, entry.getFilesEntry().get(2).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
   
 	private void assertCommit07Alt(LogEntry entry) {
@@ -721,63 +829,87 @@ public class MainEntryTest {
 	}
 
 	private void assertCommit06(LogEntry entry) {
+		assertCommit06(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit06(LogEntry entry, String author) {
 		assertEquals("Readme file for the project", entry.getComment());
 		assertEquals(1, entry.getFilesEntry().size());
 		assertEquals("doc/README", entry.getFilesEntry().get(0).getPath());
 		assertEquals(GitFileType.NullFile, entry.getFilesEntry().get(0).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(0).getToType());
 		assertEquals(LogEntry.TypeOfModification.Addition, entry.getFilesEntry().get(0).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
 
 	private void assertCommit05(LogEntry entry) {
+		assertCommit05(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit05(LogEntry entry, String author) {
 		assertEquals("This class represent the Project class exist in starteam", entry.getComment());
 		assertEquals(1, entry.getFilesEntry().size());
 		assertEquals("src/java/starteam/Project.java", entry.getFilesEntry().get(0).getPath());
 		assertEquals(GitFileType.NullFile, entry.getFilesEntry().get(0).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(0).getToType());
 		assertEquals(LogEntry.TypeOfModification.Addition, entry.getFilesEntry().get(0).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
 
 	private void assertCommit04(LogEntry entry) {
+		assertCommit04(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit04(LogEntry entry, String author) {
 		assertEquals("This class represent the Item class exist in starteam", entry.getComment());
 		assertEquals(1, entry.getFilesEntry().size());
 		assertEquals("src/java/starteam/Item.java", entry.getFilesEntry().get(0).getPath());
 		assertEquals(GitFileType.NullFile, entry.getFilesEntry().get(0).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(0).getToType());
 		assertEquals(LogEntry.TypeOfModification.Addition, entry.getFilesEntry().get(0).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
 
 	private void assertCommit03(LogEntry entry) {
+		assertCommit03(entry, "Test <Test@test.com>");
+	}
+
+	private void assertCommit03(LogEntry entry, String author) {
 		assertEquals("This class represent the File class exist in starteam", entry.getComment());
 		assertEquals(1, entry.getFilesEntry().size());
 		assertEquals("src/java/starteam/File.java", entry.getFilesEntry().get(0).getPath());
 		assertEquals(GitFileType.NullFile, entry.getFilesEntry().get(0).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(0).getToType());
 		assertEquals(LogEntry.TypeOfModification.Addition, entry.getFilesEntry().get(0).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
 
 	private void assertCommit02(LogEntry entry) {
+		assertCommit02(entry, "Test <Test@test.com>");
+	}
+	
+	private void assertCommit02(LogEntry entry, String author) {
 		assertEquals("The initial version of the sconstruct file of mesa", entry.getComment());
 		assertEquals(1, entry.getFilesEntry().size());
 		assertEquals("src/scons/SConstruct", entry.getFilesEntry().get(0).getPath());
 		assertEquals(GitFileType.NullFile, entry.getFilesEntry().get(0).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(0).getToType());
 		assertEquals(LogEntry.TypeOfModification.Addition, entry.getFilesEntry().get(0).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
 
 	private void assertCommit01(LogEntry entry) {
+		assertCommit01(entry, "Test <Test@test.com>");
+	}
+	
+	private void assertCommit01(LogEntry entry, String author) {
 		assertEquals("First version of glsl mesa lexer", entry.getComment());
 		assertEquals(1, entry.getFilesEntry().size());
 		assertEquals("src/cpp/mesa/glsl/glsl_lexer.ll", entry.getFilesEntry().get(0).getPath());
 		assertEquals(GitFileType.NullFile, entry.getFilesEntry().get(0).getFromType());
 		assertEquals(GitFileType.Normal, entry.getFilesEntry().get(0).getToType());
 		assertEquals(LogEntry.TypeOfModification.Addition, entry.getFilesEntry().get(0).getTypeOfModification());
-		assertEquals("Test <Test@test.com>", entry.getAuthor());
+		assertEquals(author, entry.getAuthor());
 	}
 	
   private void assertSubCommit30(LogEntry entry) {

--- a/syncronizer/test/org/sync/test/UserMappingTest.java
+++ b/syncronizer/test/org/sync/test/UserMappingTest.java
@@ -1,7 +1,6 @@
 package org.sync.test;
 
 import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -34,7 +33,7 @@ public class UserMappingTest {
 
 	    final String filename = "some inexistant file.txt";
 		UserMapping directory = new UserMapping(filename);
-	    assertThat(outContent.toString(), containsString("Email mapping file \"" + filename + "\" not found."));		
+	    assertTrue(outContent.toString().contains("Email mapping file \"" + filename + "\" not found."));		
 	}
 
 	@Test
@@ -44,7 +43,7 @@ public class UserMappingTest {
 	    System.setErr(new PrintStream(outContent));
 
 		UserMapping directory = new UserMapping(new ByteArrayInputStream(cases.getBytes()));
-	    assertThat(outContent.toString(), containsString("Invalid email mapping at line 1: John Smith"));		
+		assertTrue(outContent.toString().contains("Invalid email mapping at line 1: John Smith"));		
 	}
 	
 	@Test

--- a/syncronizer/test/org/sync/test/UserMappingTest.java
+++ b/syncronizer/test/org/sync/test/UserMappingTest.java
@@ -1,6 +1,7 @@
 package org.sync.test;
 
 import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.containsString;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/syncronizer/test/org/sync/test/UserMappingTest.java
+++ b/syncronizer/test/org/sync/test/UserMappingTest.java
@@ -38,31 +38,44 @@ public class UserMappingTest {
 
 	@Test
 	public void testInvalidEntry() {
-		String cases = "John Smith\n";
+		String cases = "John Smith\n"
+				+ "1 Invalid User - = \"1w@\"@1.-\n"
+				+ "Another Invalid_User = 1w@1._\n"
+				+ "=\n"
+				+ "John = 1.\n"
+				;
 		ByteArrayOutputStream outContent = new ByteArrayOutputStream();
 	    System.setErr(new PrintStream(outContent));
 
 		UserMapping directory = new UserMapping(new ByteArrayInputStream(cases.getBytes()));
 		assertTrue(outContent.toString().contains("Invalid email mapping at line 1: John Smith"));		
+		assertTrue(outContent.toString().contains("Invalid email mapping at line 2: 1 Invalid User - = \"1w@\"@1.-"));		
+		assertTrue(outContent.toString().contains("Invalid email mapping at line 3: Another Invalid_User = 1w@1._"));		
+		assertTrue(outContent.toString().contains("Invalid email mapping at line 4: ="));		
+		assertTrue(outContent.toString().contains("Invalid email mapping at line 5: John = 1."));		
 	}
 	
 	@Test
 	public void testGetEmail() {
 		String cases = "# Email mapping\n" 
 				+ "John Smith = jsmith@email.com\n"
-	            + "Jane Doe = jdoe@users.email.com # some user\n"
+	            + "Jane Doe = jdoe@users.email.com\n"
+				+ "1 Weird User _ = \"w@\"@[1.2.3.4]\n"
+	            + "Another Weird User = #{`@1.2\n"
 				;
 		UserMapping directory = new UserMapping(new ByteArrayInputStream(cases.getBytes()));
 		assertEquals("jsmith@email.com", directory.getEmail("John Smith"));
 		assertEquals("jdoe@users.email.com", directory.getEmail("Jane Doe"));
+		assertEquals("\"w@\"@[1.2.3.4]", directory.getEmail("1 Weird User _"));
+		assertEquals("#{`@1.2", directory.getEmail("Another Weird User"));
 		assertEquals("unknown@noreply.com", directory.getEmail("John Doe"));
 	}
 
 	@Test
 	public void testGetEmailDefaultDomain() {
-		String cases = "# Email mapping\n" 
+		String cases = " # Email mapping\n" 
 				+ "John Smith = jsmith@email.com\n"
-	            + "Jane Doe = jdoe@users.email.com # some user\n"
+	            + "Jane Doe = jdoe@users.email.com\n"
 		        ;
 		UserMapping directory = new UserMapping(new ByteArrayInputStream(cases.getBytes()));
 		directory.setDefaultDomain("acme.com");

--- a/syncronizer/test/org/sync/test/UserMappingTest.java
+++ b/syncronizer/test/org/sync/test/UserMappingTest.java
@@ -8,7 +8,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 public class UserMappingTest {
@@ -35,7 +34,7 @@ public class UserMappingTest {
 
 	    final String filename = "some inexistant file.txt";
 		UserMapping directory = new UserMapping(filename);
-	    assertThat(outContent.toString(), CoreMatchers.containsString("Email mapping file \"" + filename + "\" not found."));		
+	    assertThat(outContent.toString(), containsString("Email mapping file \"" + filename + "\" not found."));		
 	}
 
 	@Test
@@ -45,7 +44,7 @@ public class UserMappingTest {
 	    System.setErr(new PrintStream(outContent));
 
 		UserMapping directory = new UserMapping(new ByteArrayInputStream(cases.getBytes()));
-	    assertThat(outContent.toString(), CoreMatchers.containsString("Invalid email mapping at line 1: John Smith"));		
+	    assertThat(outContent.toString(), containsString("Invalid email mapping at line 1: John Smith"));		
 	}
 	
 	@Test

--- a/syncronizer/test/org/sync/test/UserMappingTest.java
+++ b/syncronizer/test/org/sync/test/UserMappingTest.java
@@ -1,0 +1,75 @@
+package org.sync.test;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+public class UserMappingTest {
+
+	protected class UserMapping extends org.sync.UserMapping {
+		public UserMapping(String filename) {
+			  super(filename);
+			}
+		public UserMapping(InputStream stream) {
+		  super(stream);
+		}
+	}
+	
+	@Test
+	public void testNullFile() {
+	    final String filename = null;
+		UserMapping directory = new UserMapping(filename);
+	}
+
+	@Test
+	public void testInvalidFile() {
+		ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+	    System.setErr(new PrintStream(outContent));
+
+	    final String filename = "some inexistant file.txt";
+		UserMapping directory = new UserMapping(filename);
+	    assertThat(outContent.toString(), CoreMatchers.containsString("Email mapping file \"" + filename + "\" not found."));		
+	}
+
+	@Test
+	public void testInvalidEntry() {
+		String cases = "John Smith\n";
+		ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+	    System.setErr(new PrintStream(outContent));
+
+		UserMapping directory = new UserMapping(new ByteArrayInputStream(cases.getBytes()));
+	    assertThat(outContent.toString(), CoreMatchers.containsString("Invalid email mapping at line 1: John Smith"));		
+	}
+	
+	@Test
+	public void testGetEmail() {
+		String cases = "# Email mapping\n" 
+				+ "John Smith = jsmith@email.com\n"
+	            + "Jane Doe = jdoe@users.email.com # some user\n"
+				;
+		UserMapping directory = new UserMapping(new ByteArrayInputStream(cases.getBytes()));
+		assertEquals("jsmith@email.com", directory.getEmail("John Smith"));
+		assertEquals("jdoe@users.email.com", directory.getEmail("Jane Doe"));
+		assertEquals("unknown@noreply.com", directory.getEmail("John Doe"));
+	}
+
+	@Test
+	public void testGetEmailDefaultDomain() {
+		String cases = "# Email mapping\n" 
+				+ "John Smith = jsmith@email.com\n"
+	            + "Jane Doe = jdoe@users.email.com # some user\n"
+		        ;
+		UserMapping directory = new UserMapping(new ByteArrayInputStream(cases.getBytes()));
+		directory.setDefaultDomain("acme.com");
+		assertEquals("jsmith@email.com", directory.getEmail("John Smith"));
+		assertEquals("jdoe@users.email.com", directory.getEmail("Jane Doe"));
+		assertEquals("John.Doe@acme.com", directory.getEmail("John Doe"));
+		assertEquals("J.Random.Hacker@acme.com", directory.getEmail("J. Random Hacker"));
+	}
+}


### PR DESCRIPTION
The feature is provided as fallback mechanism in case the user calling git-starteam does not have StarTeam user account admin access required to obtain the email addresses directly from the server. 
Main implementation can be found in `UserMapping.java` used from `GitImporter` as configured in `MainEntry`. The rest of the changes are to support testing.