### PR TITLE
Fixed call to retrieve parent's date when resuming importation.

### DIFF
--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -615,9 +615,14 @@ public class GitImporter {
 			
 			if(i == fromLabel && isResume) {
 				SmallRef targettedHead = new SmallRef(head);
-				List<LogEntry> oldCommits = repositoryHelper.getCommitLog(targettedHead, targettedHead);
+				List<LogEntry> oldCommits = repositoryHelper.getCommitLog(targettedHead);
 				if (oldCommits.size() > 0) {
 					CheckoutStrategy.setLastCommitTime(oldCommits.get(0).getTimeOfCommit());
+				}
+				else {
+					if (verbose) {
+						Log.log("No parent commit found while resuming importation for <" + head + ">");
+					}					
 				}
 				CheckoutStrategy.setInitialPathList(repositoryHelper.getListOfTrackedFile(head));
 			}

--- a/syncronizer/src/org/sync/commitstrategy/BasePopulationStrategy.java
+++ b/syncronizer/src/org/sync/commitstrategy/BasePopulationStrategy.java
@@ -487,7 +487,7 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 		String comment = correctedComment(fileToCommit);
 		// This is a patchup time to prevent commit jumping up in time between view labels
 		long timeOfCommit = fileToCommit.getModifiedTime().getLongValue();
-		if (earliestTime != null && earliestTime.getTime() > timeOfCommit) {
+		if (earliestTime != null && earliestTime.getTime() >= timeOfCommit) {
 			// add offset with last commit to keep order. Based on the last commit
 			// from the previous pass + 1 second by counter
 			long newTime = earliestTime.getTime() + (1000 * iterationCounter);

--- a/syncronizer/test/org/sync/githelper/test/GitHelperTest.java
+++ b/syncronizer/test/org/sync/githelper/test/GitHelperTest.java
@@ -180,7 +180,7 @@ public class GitHelperTest {
 	@Test
 	public void testLogEntry() {
 		List<LogEntry> renamedLog = test.getCommitLog(new SmallRef("e09d507"));
-    assertTrue(renamedLog.size() > 0);
+		assertTrue(renamedLog.size() > 0);
 		assertEquals("Steve Tousignant <s.tousignant@gmail.com>", renamedLog.get(0).getAuthor());
 		assertEquals("MD5Builder is better placed in the util package.", renamedLog.get(0).getComment());
 		assertEquals(new Sha1Ref("e09d5071e480a2f4906dd8fae05afdbdf3492415"), renamedLog.get(0).getCommitRef());
@@ -196,6 +196,28 @@ public class GitHelperTest {
 		assertEquals(98, renamedLog.get(0).getFilesEntry().get(1).getDiffRatio());
 	}
   
+	@Test
+	public void testEmptyRangeLogEntry() {
+		SmallRef ref = new SmallRef("e09d507");
+		List<LogEntry> renamedLog = test.getCommitLog(ref, ref);
+		assertEquals(0, renamedLog.size());
+	}
+
+	@Test
+	public void testFirstLogEntry() {
+		SmallRef ref = new SmallRef("2e53773");
+		List<LogEntry> renamedLog = test.getCommitLog(ref);
+		assertEquals(1, renamedLog.size());
+	}
+
+	@Test
+	public void testBeforeFirstLogEntry() {
+		SmallRef ref = new SmallRef("2e53773");
+		// Invalid ref trying to go earlier than first commit
+		List<LogEntry> renamedLog = test.getCommitLog(ref.back(1), ref);
+		assertEquals(0, renamedLog.size());
+	}
+	
   @Test
   public void testCatBlob() throws NoSuchAlgorithmException {
     ByteArrayOutputStream stream = new ByteArrayOutputStream(4096);


### PR DESCRIPTION
- `repositoryHelper.getCommitLog(targettedHead, targettedHead)` (evaluating to the equivalent of "git log ref..ref") was returning an empty list of commits. Using `repositoryHelper.getCommitLog(targettedHead)` instead gives the list of commit up-to-and-including the desired `targettedHead`.
Note that `repositoryHelper.getCommitLog(targettedHead.back(1), targettedHead)` should be avoided in case where  `targettedHead` happens to be the very first commit of the repo.
- Also update the `timeOfCommit` in `BasePopulationStrategy` to ensure the first new commit on a newly imported branch is a bit later than the parent's commit when it happens to be exactly the same as the `earliestTime` (obtained from the parent's commit time during resume).