### PR TITLE
Fix #49

### DIFF
--- a/syncronizer/src/org/sync/githelper/GitHelper.java
+++ b/syncronizer/src/org/sync/githelper/GitHelper.java
@@ -384,7 +384,11 @@ public class GitHelper extends RepositoryHelper {
 	@Override
 	public Date getLastCommitOfBranch(String branchName) {
 		SmallRef to = new SmallRef(branchName);
-		return getCommitLog(to.back(1), to).get(0).getTimeOfCommit();
+		List<LogEntry> commits = getCommitLog(to.back(1), to);
+		if (commits.size() <= 0) {
+			commits = getCommitLog(to);
+		}
+		return commits.get(0).getTimeOfCommit();
 	}
 	
 	@Override


### PR DESCRIPTION
Check for the special case where there is only one commit which would result in an empty list (thus causing the `IndexOutOfBoundsException` mentionned in issue #49) when requesting `branch~1..branch` to get the last commit.