### PR TITLE
Create commit whenever files is replaced

### DIFF
--- a/syncronizer/src/org/sync/commitstrategy/BasePopulationStrategy.java
+++ b/syncronizer/src/org/sync/commitstrategy/BasePopulationStrategy.java
@@ -187,7 +187,10 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 		}
 		// prefer content version as it is cached in the File object
 		int itemViewVersion = historyFile.getContentVersion();
-		if (previousContentVersion < 0) {
+		if (fileid != null && fileid != historyFile.getItemID()) {
+			Log.logf("File %s was replaced", path);			
+			createCommitInformation(path, historyFile, 1);
+		} else if (previousContentVersion < 0) {
 			createCommitInformation(path, historyFile, 1);
 		} else if (previousContentVersion > itemViewVersion) {
 			Log.logf("File %s was reverted from version %d to %d was skipped", path, previousContentVersion,


### PR DESCRIPTION
In cases where a file was deleted or moved and a new file with the same name created at the original location with a revision number matching the previously imported label, the conversion would fail to detect the change (even if the file content was completely different).
Thus we create a commit if the file's itemID has changed, regardless of the revision number.