### PR TITLE
Bugfix/cleanup after janitor

### DIFF
--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -413,6 +413,7 @@ public class GitImporter {
 						} catch (InvalidPathException e1) {
 							e1.printStackTrace();
 						}
+						repositoryHelper.unregisterFileId(head, path);
 					}
 				}
 				lastCommit = commit;

--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -385,6 +385,9 @@ public class GitImporter {
 				java.util.Date janitorTime;
 				if(view.getConfiguration().isTimeBased()) {
 					janitorTime = new java.util.Date(view.getConfiguration().getTime().getLongValue());
+					if (janitorTime.before(lastCommit.getCommitDate())) {
+						janitorTime = new java.util.Date(lastCommit.getCommitDate().getTime() + 1000);
+					}
 				} else {
 					janitorTime = lastCommit.getCommitDate(); //At this stage, there should always be a last commit
 				}


### PR DESCRIPTION
This includes a few small fixes to janitor related file deletions:
- In case where files were deleted in a commit by the file janitor but the files reappeared at a later time (e.g. because file was not really deleted and it was attached to a new imported or file was actually deleted in starteam but got reshared from a past configuration) the files would never be added back. By unregistering the files in the repositoryHelper, the files are now added back the next time they are seen.
- Since revision labels are imported by first rolling back to the build date, the view configuration during the importation is time based. As a result, the commit date on the commit by the janitor could have been out-of-order with respect to the previous commit. Made sure to also adjust the commit date in that case.