### PR TITLE
Feature/author date from checkin

### DIFF
--- a/fake-starteam/src/com/starbase/util/OLEDate.java
+++ b/fake-starteam/src/com/starbase/util/OLEDate.java
@@ -50,4 +50,8 @@ public class OLEDate {
 			return System.currentTimeMillis();
 		}
 	}
+	
+	public java.util.Date createDate() {
+		return new java.util.Date(javaTime);
+	}
 }

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -35,6 +35,7 @@ public class Commit implements Markable {
 	private DataRef fromRef;
 	private Map<String, FileOperation> listOfOperation;
 	private Date commitDate;
+	private Date authorDate;
 	private boolean resumeFastImport;
 	private boolean written;
   private GitAttributes filesAttributes;
@@ -56,6 +57,10 @@ public class Commit implements Markable {
 	public void setAuthor(String name, String email) {
 		authorName = name;
 		authorEmail = email;
+	}
+	
+	public void setAuthorDate(Date date) {
+		authorDate = date;
 	}
 	
 	public void setFromCommit(Commit previous) {
@@ -111,10 +116,19 @@ public class Commit implements Markable {
 		mark.writeTo(out);
 		commitMsg.setLength(0);
 		if(null != authorName  && null != authorEmail) {
+			Date date = commitDate;
+			if (null != authorDate) {
+				date = authorDate;
+			}
 			commitMsg.append(AUTHOR).append(' ').append(authorName).append(' ')
 					 .append('<').append(authorEmail).append('>').append(' ')
-					 .append(commitDate.getTime() / 1000).append(' ').append(DATEFORMAT.format(commitDate))
+					 .append(date.getTime() / 1000).append(' ').append(DATEFORMAT.format(date))
 					 .append('\n');
+		} else if (null != authorDate) {
+			commitMsg.append(AUTHOR).append(' ').append(commiterName).append(' ')
+			 .append('<').append(commiterEmail).append('>').append(' ')
+			 .append(authorDate.getTime() / 1000).append(' ').append(DATEFORMAT.format(authorDate))
+			 .append('\n');			
 		}
 		commitMsg.append(COMMITTER).append(' ').append(commiterName).append(' ')
 				 .append('<').append(commiterEmail).append('>').append(' ')

--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -171,7 +171,7 @@ public class GitImporter {
 		cm.getOptions().setEOLConversionEnabled(false);
 		// Disabling status update leads to a large performance increase.
 		cm.getOptions().setUpdateStatus(false);
-		lastInformation = new CommitInformation(Long.MIN_VALUE, Integer.MIN_VALUE, "", "");
+		lastInformation = new CommitInformation(new java.util.Date(0), Integer.MIN_VALUE, "", "");
 
 		folder = null;
 		setFolder(view, folderPath);

--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -199,8 +199,8 @@ public class GitImporter {
 			if (!commitList.isEmpty()) {
 				CommitInformation earliest = commitList.firstKey();
 				CommitInformation latest = commitList.lastKey();
-				Log.log("Earliest file: " + earliest.getPath() + " @ " + new java.util.Date(earliest.getTime()));
-				Log.log("Latest file: " + latest.getPath() + " @ " + new java.util.Date(latest.getTime()));
+				Log.log("Earliest file: " + earliest.getPath() + " @ " + earliest.getCommitDate().getTime());
+				Log.log("Latest file: " + latest.getPath() + " @ " + latest.getCommitDate().getTime());
 			}
 		}
 
@@ -338,9 +338,9 @@ public class GitImporter {
 						lastCommit.setAttributes(fattributes);
 					}
 				} else {
-					java.util.Date commitDate = new java.util.Date(current.getTime());
+					java.util.Date commitDate = current.getCommitDate();
 					// validate that the last commit done wasn't newer than the commit we will be doing
-					if (null != lastCommit && lastCommit.getCommitDate().getTime() >= current.getTime()) {
+					if (null != lastCommit && !current.getCommitDate().after(lastCommit.getCommitDate())) {
 						// we add a seconds for each time we see a commit that is newer or same as the previous commit.
 						commitDate = new java.util.Date(lastCommit.getCommitDate().getTime() + 1000);
 					}
@@ -807,7 +807,7 @@ public class GitImporter {
 				CommitPopulationStrategy baseStrategy = new BasePopulationStrategy(baseView);
 				baseStrategy.filePopulation(alternateHead, folder);
 				lastFiles.addAll(baseStrategy.getLastFiles());
-				startDate = new java.util.Date(baseStrategy.getListOfCommit().lastKey().getTime());
+				startDate = baseStrategy.getListOfCommit().lastKey().getCommitDate();
 				baseView.close();
 			}
 			lastCommit = null;

--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -199,8 +199,8 @@ public class GitImporter {
 			if (!commitList.isEmpty()) {
 				CommitInformation earliest = commitList.firstKey();
 				CommitInformation latest = commitList.lastKey();
-				Log.log("Earliest file: " + earliest.getPath() + " @ " + earliest.getCommitDate().getTime());
-				Log.log("Latest file: " + latest.getPath() + " @ " + latest.getCommitDate().getTime());
+				Log.log("Earliest file: " + earliest.getPath() + " @ " + new java.util.Date(earliest.getTime()));
+				Log.log("Latest file: " + latest.getPath() + " @ " + new java.util.Date(latest.getTime()));
 			}
 		}
 
@@ -338,9 +338,9 @@ public class GitImporter {
 						lastCommit.setAttributes(fattributes);
 					}
 				} else {
-					java.util.Date commitDate = current.getCommitDate();
+					java.util.Date commitDate = new java.util.Date(current.getTime());
 					// validate that the last commit done wasn't newer than the commit we will be doing
-					if (null != lastCommit && !current.getCommitDate().after(lastCommit.getCommitDate())) {
+					if (null != lastCommit && lastCommit.getCommitDate().getTime() >= current.getTime()) {
 						// we add a seconds for each time we see a commit that is newer or same as the previous commit.
 						commitDate = new java.util.Date(lastCommit.getCommitDate().getTime() + 1000);
 					}
@@ -807,7 +807,7 @@ public class GitImporter {
 				CommitPopulationStrategy baseStrategy = new BasePopulationStrategy(baseView);
 				baseStrategy.filePopulation(alternateHead, folder);
 				lastFiles.addAll(baseStrategy.getLastFiles());
-				startDate = baseStrategy.getListOfCommit().lastKey().getCommitDate();
+				startDate = new java.util.Date(baseStrategy.getListOfCommit().lastKey().getTime());
 				baseView.close();
 			}
 			lastCommit = null;

--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -345,6 +345,7 @@ public class GitImporter {
 						commitDate = new java.util.Date(lastCommit.getCommitDate().getTime() + 1000);
 					}
 					commit = new Commit(userName, userEmail, current.getComment(), head, commitDate);
+					commit.setAuthorDate(current.getAuthorDate());
 					
 					commit.addFileOperation(fo);
 					if (fattributes != null) {

--- a/syncronizer/src/org/sync/commitstrategy/BasePopulationStrategy.java
+++ b/syncronizer/src/org/sync/commitstrategy/BasePopulationStrategy.java
@@ -486,7 +486,8 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 	protected void createCommitInformation(String path, File fileToCommit, int iterationCounter) {
 		String comment = correctedComment(fileToCommit);
 		// This is a patchup time to prevent commit jumping up in time between view labels
-		long timeOfCommit = fileToCommit.getModifiedTime().getLongValue();
+		Date authorDate = new java.util.Date(fileToCommit.getModifiedTime().getLongValue());
+		long timeOfCommit = authorDate.getTime();
 		if (earliestTime != null && earliestTime.getTime() >= timeOfCommit) {
 			// add offset with last commit to keep order. Based on the last commit
 			// from the previous pass + 1 second by counter
@@ -499,6 +500,7 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 		Date commitDate = new java.util.Date(timeOfCommit);
 
 		CommitInformation info = new CommitInformation(commitDate, fileToCommit.getModifiedBy(), comment, path);
+		info.setAuthorDate(authorDate);
 		if (verbose) {
 			Log.log("Discovered commit <" + info + ">");
 		}

--- a/syncronizer/src/org/sync/commitstrategy/BasePopulationStrategy.java
+++ b/syncronizer/src/org/sync/commitstrategy/BasePopulationStrategy.java
@@ -92,7 +92,7 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 		lastFiles.removeAll(deletedFiles); // clean files that was never seen from the last files.
 		recoverDeleteInformation(head, root);
 		if (currentCommitList.size() > 0) {
-			setLastCommitTime(new java.util.Date(currentCommitList.lastKey().getTime()));
+			setLastCommitTime(currentCommitList.lastKey().getCommitDate());
 		}
 	}
 
@@ -331,7 +331,7 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 								    path, newPath,
 										renameEventItem.getModifiedTime());
 							}
-							deleteInfo = new CommitInformation(renameEventItem.getModifiedTime().getLongValue(),
+							deleteInfo = new CommitInformation(renameEventItem.getModifiedTime().createDate(),
 									renameEventItem.getModifiedBy(),
 									"",
 									path);
@@ -345,7 +345,7 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 							// Not sure how this happens, but fill in with the
 							// only information we have: the last view time
 							// and the last person to modify the item.
-							deleteInfo = new CommitInformation(earliestTime.getTime(), item.getModifiedBy(), "", path);
+							deleteInfo = new CommitInformation(earliestTime, item.getModifiedBy(), "", path);
 						}
 						deleteInfo.setFileDelete(true);
 						ith.remove();
@@ -353,7 +353,7 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 
 						currentCommitList.put(deleteInfo, item);
 						// Replace the existing entries for item if they have an earlier timestamp.
-						CommitInformation info = new CommitInformation(deleteInfo.getTime(), deleteInfo.getUid(), "", newPath);
+						CommitInformation info = new CommitInformation(deleteInfo.getCommitDate(), deleteInfo.getUid(), "", newPath);
 						replaceEarlierCommitInfo(info, item, root);
 					}
 				}
@@ -380,7 +380,7 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 			}
 			for (int i = 0; i < deletedpaths.size(); i++) {
 				File item = deletedpaths.get(i).getSecond();
-				CommitInformation info = new CommitInformation(item.getDeletedTime().getLongValue(),
+				CommitInformation info = new CommitInformation(item.getDeletedTime().createDate(),
 						item.getDeletedUserID(),
 						"",
 						deletedpaths.get(i).getFirst());
@@ -412,7 +412,7 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 				originalValue = entry.getValue();
 				// Time need to match with the delete instruction to be combined
 				// together
-				replacement = new CommitInformation(earliestTime.getTime(), entry.getKey().getUid(), "Unexpected Move",
+				replacement = new CommitInformation(earliestTime, entry.getKey().getUid(), "Unexpected Move",
 				    newPath);
 				it.remove();
 				break;
@@ -441,7 +441,7 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 		// TODO: a better data structure for fileList would make this more efficient.
 		for(Iterator<Map.Entry<CommitInformation, File>> ith = currentCommitList.entrySet().iterator(); ith.hasNext(); ) {
 			CommitInformation info2 = ith.next().getKey();
-			if (path.equals(info2.getPath()) && info2.getTime() < info.getTime()) {
+			if (path.equals(info2.getPath()) && info2.getCommitDate().before(info.getCommitDate())) {
 				ith.remove();
 				return;
 			}
@@ -496,8 +496,9 @@ public class BasePopulationStrategy implements CommitPopulationStrategy {
 			}
 			timeOfCommit = newTime;
 		}
+		Date commitDate = new java.util.Date(timeOfCommit);
 
-		CommitInformation info = new CommitInformation(timeOfCommit, fileToCommit.getModifiedBy(), comment, path);
+		CommitInformation info = new CommitInformation(commitDate, fileToCommit.getModifiedBy(), comment, path);
 		if (verbose) {
 			Log.log("Discovered commit <" + info + ">");
 		}

--- a/syncronizer/src/org/sync/util/CommitInformation.java
+++ b/syncronizer/src/org/sync/util/CommitInformation.java
@@ -27,25 +27,12 @@ public final class CommitInformation implements Comparable<CommitInformation> {
 
 	private Date commitDate;
 	private Date authorDate;
-	private long time;
 	private int uid;
 	private String comment;
 	private String path;
 	private boolean fileDelete;
 
-	@Deprecated
-	public CommitInformation(long time, int uid, String comment, String path) {
-		this.time = time;
-		this.commitDate = new java.util.Date(time);
-		this.authorDate = this.commitDate;
-		this.uid = uid;
-		this.comment = comment.trim();
-		this.path = path;
-		this.fileDelete = false;
-	}
-	
 	public CommitInformation(Date date, int uid, String comment, String path) {
-		this.time = date.getTime();
 		this.commitDate = date;
 		this.authorDate = this.commitDate;
 		this.uid = uid;
@@ -54,11 +41,6 @@ public final class CommitInformation implements Comparable<CommitInformation> {
 		this.fileDelete = false;
 	}
 	
-	@Deprecated
-	public long getTime() {
-		return time;
-	}
-
 	public Date getCommitDate() {
 		return commitDate;
 	}

--- a/syncronizer/src/org/sync/util/CommitInformation.java
+++ b/syncronizer/src/org/sync/util/CommitInformation.java
@@ -27,12 +27,25 @@ public final class CommitInformation implements Comparable<CommitInformation> {
 
 	private Date commitDate;
 	private Date authorDate;
+	private long time;
 	private int uid;
 	private String comment;
 	private String path;
 	private boolean fileDelete;
 
+	@Deprecated
+	public CommitInformation(long time, int uid, String comment, String path) {
+		this.time = time;
+		this.commitDate = new java.util.Date(time);
+		this.authorDate = this.commitDate;
+		this.uid = uid;
+		this.comment = comment.trim();
+		this.path = path;
+		this.fileDelete = false;
+	}
+	
 	public CommitInformation(Date date, int uid, String comment, String path) {
+		this.time = date.getTime();
 		this.commitDate = date;
 		this.authorDate = this.commitDate;
 		this.uid = uid;
@@ -41,6 +54,11 @@ public final class CommitInformation implements Comparable<CommitInformation> {
 		this.fileDelete = false;
 	}
 	
+	@Deprecated
+	public long getTime() {
+		return time;
+	}
+
 	public Date getCommitDate() {
 		return commitDate;
 	}

--- a/syncronizer/src/org/sync/util/CommitInformation.java
+++ b/syncronizer/src/org/sync/util/CommitInformation.java
@@ -26,6 +26,7 @@ import java.util.Date;
 public final class CommitInformation implements Comparable<CommitInformation> {
 
 	private Date commitDate;
+	private Date authorDate;
 	private long time;
 	private int uid;
 	private String comment;
@@ -36,6 +37,7 @@ public final class CommitInformation implements Comparable<CommitInformation> {
 	public CommitInformation(long time, int uid, String comment, String path) {
 		this.time = time;
 		this.commitDate = new java.util.Date(time);
+		this.authorDate = this.commitDate;
 		this.uid = uid;
 		this.comment = comment.trim();
 		this.path = path;
@@ -45,6 +47,7 @@ public final class CommitInformation implements Comparable<CommitInformation> {
 	public CommitInformation(Date date, int uid, String comment, String path) {
 		this.time = date.getTime();
 		this.commitDate = date;
+		this.authorDate = this.commitDate;
 		this.uid = uid;
 		this.comment = comment.trim();
 		this.path = path;
@@ -60,6 +63,13 @@ public final class CommitInformation implements Comparable<CommitInformation> {
 		return commitDate;
 	}
 
+	public void setAuthorDate(Date date) {
+		authorDate = date;
+	}
+
+	public Date getAuthorDate() {
+		return authorDate;
+	}
 	
 	public int getUid() {
 		return uid;
@@ -84,7 +94,13 @@ public final class CommitInformation implements Comparable<CommitInformation> {
 	
 	@Override
 	public String toString() {
-		return "CommitInfo: " + getTime() + " - " + getUid() + " - " + getComment() + " - " + getPath();
+		StringBuilder builder = new StringBuilder();
+		builder.append("CommitInfo: " + getCommitDate().getTime());
+		if (null != getAuthorDate() && !getAuthorDate().equals(getCommitDate())) {
+			builder.append("/" + getAuthorDate().getTime());
+		}
+		builder.append(" - " + getUid() + " - " + getComment() + " - " + getPath());
+		return builder.toString();
 	}
 
 	@Override

--- a/syncronizer/src/org/sync/util/CommitInformation.java
+++ b/syncronizer/src/org/sync/util/CommitInformation.java
@@ -16,6 +16,8 @@
 ******************************************************************************/
 package org.sync.util;
 
+import java.util.Date;
+
 /**
  * Note: this class has a natural ordering that is inconsistent with equals.
  * @author Steve Tousignant <s.tousignant@gmail.com>
@@ -23,23 +25,41 @@ package org.sync.util;
  */
 public final class CommitInformation implements Comparable<CommitInformation> {
 
+	private Date commitDate;
 	private long time;
 	private int uid;
 	private String comment;
 	private String path;
 	private boolean fileDelete;
 
+	@Deprecated
 	public CommitInformation(long time, int uid, String comment, String path) {
 		this.time = time;
+		this.commitDate = new java.util.Date(time);
 		this.uid = uid;
 		this.comment = comment.trim();
 		this.path = path;
 		this.fileDelete = false;
 	}
 	
+	public CommitInformation(Date date, int uid, String comment, String path) {
+		this.time = date.getTime();
+		this.commitDate = date;
+		this.uid = uid;
+		this.comment = comment.trim();
+		this.path = path;
+		this.fileDelete = false;
+	}
+	
+	@Deprecated
 	public long getTime() {
 		return time;
 	}
+
+	public Date getCommitDate() {
+		return commitDate;
+	}
+
 	
 	public int getUid() {
 		return uid;
@@ -71,14 +91,14 @@ public final class CommitInformation implements Comparable<CommitInformation> {
 	public boolean equals(Object obj) {
 		if(obj instanceof CommitInformation) {
 			CommitInformation info = (CommitInformation) obj;
-			return time == info.getTime() && uid == info.getUid() && comment.equalsIgnoreCase(info.getComment());
+			return getCommitDate().equals(info.getCommitDate()) && uid == info.getUid() && comment.equalsIgnoreCase(info.getComment());
 		}
 		return false;
 	}
 
 	@Override
 	public int compareTo(CommitInformation o) {
-		if(time == o.time) {
+		if(getCommitDate().equals(o.getCommitDate())) {
 			if(uid == o.uid) {
 				if(comment.length() == 0) {
 					return path.compareTo(o.getPath());
@@ -92,7 +112,7 @@ public final class CommitInformation implements Comparable<CommitInformation> {
 				return 1;
 			}
 			return -1;
-		} else if (time > o.time) {
+		} else if (getCommitDate().after(o.getCommitDate())) {
 			return 1;
 		}
 		return -1;

--- a/syncronizer/test/org/sync/commitstrategy/test/BasePopulationTest.java
+++ b/syncronizer/test/org/sync/commitstrategy/test/BasePopulationTest.java
@@ -134,7 +134,7 @@ public class BasePopulationTest {
 	@After
 	public void tearDown() throws Exception {
 		LastFiles = CommitBuilder.getLastFiles();
-		EarliestTime = new java.util.Date(CommitBuilder.getListOfCommit().lastKey().getTime());
+		EarliestTime = CommitBuilder.getListOfCommit().lastKey().getCommitDate();
 		CommitBuilder = null;
 		SelectedViewLabels = null;
 	}

--- a/syncronizer/test/org/sync/commitstrategy/test/RevisionPopulationTest.java
+++ b/syncronizer/test/org/sync/commitstrategy/test/RevisionPopulationTest.java
@@ -136,7 +136,7 @@ public class RevisionPopulationTest {
 	@After
 	public void tearDown() throws Exception {
 		LastFiles = CommitBuilder.getLastFiles();
-		EarliestTime = new java.util.Date(CommitBuilder.getListOfCommit().lastKey().getTime());
+		EarliestTime = CommitBuilder.getListOfCommit().lastKey().getCommitDate();
 		CommitBuilder = null;
 		SelectedViewLabels = null;
 	}


### PR DESCRIPTION
Track original check-in date as the commit's author date, in addition to the commit date which is adjusted to make the commits sequentially ordered (as the commits depends not only on individual files check-in dates, but also other importation label manipulation (e.g. rolling back a file by attaching the build label to an older file revision). 
Also made some conversion of `long` dates (milliseconds since epoch) to `java.util.Date` in the process.