### PR TITLE
Hotfix/properly read executable property

### DIFF
--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -340,7 +340,7 @@ public class GitImporter {
 					try	{
 						if (f.get(propNames.FILE_EXECUTABLE) != null)
 						{
-							executable = (Boolean) f.get(propNames.FILE_EXECUTABLE);
+							executable = (int) f.get(propNames.FILE_EXECUTABLE) != 0;
 						}
 					}
 					catch (Exception ex) {


### PR DESCRIPTION
`FILE_EXECUTABLE` is a Integer and not a Boolean. When casting the value to Boolean, the result was always false and therefore the executable attribute was lost .

I tested the fix locally with a StarTeam repository that contains a executable (.bat and .sh) and normal xml file.

Result before the fix:

![image](https://cloud.githubusercontent.com/assets/18684867/20543903/9e715310-b0d5-11e6-9e87-18e89025fa7b.png)

Result after the fix:

![image](https://cloud.githubusercontent.com/assets/18684867/20543958/d3b997ee-b0d5-11e6-9cb6-b7b793629311.png)

You can see the `100755` value that indicate that bot file are executable.

