### PR TITLE
Move creation of repository helper to after full configuration of factory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ All four modes can:
   required administrator access to extract email addresses from the StarTeam server, and
   an explicit mapping cannot be found in the mail mapping file if one is provided 
   with the `-m <mailMappingFile>` command line option.
+* Skip files with specific extensions using the `-x <extensions>` option.
 
 The first three modes can:
 

--- a/syncronizer/src/org/sync/CommitPopulationStrategy.java
+++ b/syncronizer/src/org/sync/CommitPopulationStrategy.java
@@ -129,5 +129,14 @@ public interface CommitPopulationStrategy {
 	 * This feature is enabled by default.
 	 */
 	void setFileRemoveExtendedInformation(boolean enable);
+	
+	/**
+	 * Tell the strategy to skip files of a given extension.
+	 * 
+	 * @param skipExtensionsPattern 
+	 *          Comma separated list of extensions to exclude from commits (with no whitespace).
+	 *
+	 */
+	void setSkipExtensions(String skipExtensionsPattern);
 
 }

--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -517,13 +517,14 @@ public class GitImporter {
 	}
 
 	private Folder findFirstFolder(Folder f, String folderPattern) {
-		// Bread-first search queue
+		// Breadth-first search queue
 		Deque<Folder> deque = new ArrayDeque<Folder>();
 		deque.addLast(f);
 		while(!deque.isEmpty()) {
 			Folder folder = deque.removeFirst();
 			String path = folder.getFolderHierarchy();
 			path = path.replace('\\', '/');
+			folderPattern = folderPattern.replace('\\', '/');
 			int indexOfFirstPath = path.indexOf('/');
 
 			path = path.substring(indexOfFirstPath + 1);

--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -820,7 +820,7 @@ public class GitImporter {
 		return views;
 	}
 
-	public void generateAllViewsImport(Project project, View rootView, String baseFolder, String skipPattern) {
+	public void generateAllViewsImport(Project project, View rootView, String baseFolder, String skipPattern, String skipExtensionsPattern) {
 		List<View> views = getAllViews(project, rootView, skipPattern);
 		int count = 0;
 
@@ -856,6 +856,7 @@ public class GitImporter {
 				View baseView = new View(view.getParentView(), view.getBaseConfiguration());
 				setFolder(baseView, baseFolder);
 				CommitPopulationStrategy baseStrategy = new BasePopulationStrategy(baseView);
+				baseStrategy.setSkipExtensions(skipExtensionsPattern);
 				setCheckoutStrategy(baseStrategy);
 				baseStrategy.filePopulation(alternateHead, folder);
 				lastFiles.addAll(baseStrategy.getLastFiles());
@@ -865,7 +866,9 @@ public class GitImporter {
 			lastCommit = null;
 			isResume = false;
 
-			setCheckoutStrategy(new BasePopulationStrategy(view));
+			CommitPopulationStrategy strategy = new BasePopulationStrategy(view);
+			strategy.setSkipExtensions(skipExtensionsPattern);
+			setCheckoutStrategy(strategy);
 			CheckoutStrategy.setInitialPathList(lastFiles);
 			CheckoutStrategy.setLastCommitTime(startDate);
 			generateAllLabelImport(view, baseFolder);

--- a/syncronizer/src/org/sync/MainEntry.java
+++ b/syncronizer/src/org/sync/MainEntry.java
@@ -80,6 +80,7 @@ public class MainEntry {
 		CmdLineParser.Option isVerbose = parser.addBooleanOption("verbose");
 		CmdLineParser.Option isCheckpoint = parser.addBooleanOption("checkpoint");
 		CmdLineParser.Option selectSkipViewsPattern = parser.addStringOption("skip-views");
+		CmdLineParser.Option selectSkipExtensionsPattern = parser.addStringOption('x',"skip-ext");
 		CmdLineParser.Option trackAsLfsFromSize = parser.addStringOption("lfs-size");
 		CmdLineParser.Option trackAsLfsPattern = parser.addStringOption("lfs-pattern");
 		CmdLineParser.Option filteringViewLabel = parser.addStringOption("view-label-pattern");
@@ -111,6 +112,7 @@ public class MainEntry {
 		Boolean allViewsFlag = (Boolean) parser.getOptionValue(isAllViews);
 		boolean allViews = allViewsFlag != null && allViewsFlag;
 		String skipViewsPattern = (String) parser.getOptionValue(selectSkipViewsPattern);
+		String skipExtensionsPattern = (String) parser.getOptionValue(selectSkipExtensionsPattern);
 		String time = (String) parser.getOptionValue(selectTime);
 		Boolean timeBased = (Boolean) parser.getOptionValue(selectTimeBasedImport);
 		Boolean labelBased = (Boolean) parser.getOptionValue(selectLabelBasedImport);
@@ -309,14 +311,14 @@ public class MainEntry {
 						NetMonitor.onFile(new java.io.File("netmon.out"));
 
 						if(allViews && view == null) {
-							importer.generateAllViewsImport(p, null, folder, skipViewsPattern);
+							importer.generateAllViewsImport(p, null, folder, skipViewsPattern, skipExtensionsPattern);
 						} else {
 							boolean viewFound = false;
 							for(View v : p.getViews()) {
 								if(v.getName().trim().equalsIgnoreCase(view)) {
 									viewFound = true;
 									if(allViews) {
-										importer.generateAllViewsImport(p, v, folder, skipViewsPattern);
+										importer.generateAllViewsImport(p, v, folder, skipViewsPattern, skipExtensionsPattern);
 									} else {
 									    CommitPopulationStrategy strategy = null;
 									    if (changeRequestFilePattern != null) {
@@ -326,6 +328,7 @@ public class MainEntry {
                                         } else {
 									        strategy = new BasePopulationStrategy(v);
                                         }
+									    strategy.setSkipExtensions(skipExtensionsPattern);
                                         strategy.setFileRemoveExtendedInformation(!doNotUseRycleBin);
                                         importer.setCheckoutStrategy(strategy);
                                         if(null != timeBased && timeBased) {

--- a/syncronizer/src/org/sync/MainEntry.java
+++ b/syncronizer/src/org/sync/MainEntry.java
@@ -24,24 +24,21 @@ import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.Vector;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import java.util.Set;
 
 import org.sync.commitstrategy.BasePopulationStrategy;
 import org.sync.commitstrategy.ChangeRequestPopulationStrategy;
 import org.sync.commitstrategy.RevisionPopulationStrategy;
-import org.sync.githelper.GitHelper;
-import org.sync.RepositoryHelper;
-import org.sync.RepositoryHelperFactory;
 
 import com.starbase.starteam.ClientApplication;
 import com.starbase.starteam.Project;
 import com.starbase.starteam.Server;
-import com.starbase.util.OLEDate;
 import com.starbase.starteam.View;
 import com.starbase.starteam.vts.comm.NetMonitor;
+import com.starbase.util.OLEDate;
 
 import jargs.gnu.CmdLineParser;
 import jargs.gnu.CmdLineParser.IllegalOptionValueException;
@@ -145,7 +142,6 @@ public class MainEntry {
         String lfsSize = (String) parser.getOptionValue(trackAsLfsFromSize);
         String lfsPattern = (String) parser.getOptionValue(trackAsLfsPattern);
         String lfsConfigUrl = (String) parser.getOptionValue(selectLfsConfigUrl);
-		RepositoryHelper repositoryHelper = RepositoryHelperFactory.getFactory().createHelper();
 
 		@SuppressWarnings("rawtypes")
 		Vector excludedLabels = parser.getOptionValues(excludeLabel);
@@ -218,6 +214,7 @@ public class MainEntry {
 		if(null != workingFolder) {
 			RepositoryHelperFactory.getFactory().setWorkingFolder(workingFolder);
 		}
+		RepositoryHelper repositoryHelper = RepositoryHelperFactory.getFactory().createHelper();
 
 		ClientApplication.setName("git-starteam");
 		Server starteam = new Server(host, port);

--- a/syncronizer/src/org/sync/MainEntry.java
+++ b/syncronizer/src/org/sync/MainEntry.java
@@ -24,21 +24,24 @@ import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
 import java.util.Vector;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.Set;
 
 import org.sync.commitstrategy.BasePopulationStrategy;
 import org.sync.commitstrategy.ChangeRequestPopulationStrategy;
 import org.sync.commitstrategy.RevisionPopulationStrategy;
+import org.sync.githelper.GitHelper;
+import org.sync.RepositoryHelper;
+import org.sync.RepositoryHelperFactory;
 
 import com.starbase.starteam.ClientApplication;
 import com.starbase.starteam.Project;
 import com.starbase.starteam.Server;
+import com.starbase.util.OLEDate;
 import com.starbase.starteam.View;
 import com.starbase.starteam.vts.comm.NetMonitor;
-import com.starbase.util.OLEDate;
 
 import jargs.gnu.CmdLineParser;
 import jargs.gnu.CmdLineParser.IllegalOptionValueException;

--- a/syncronizer/src/org/sync/githelper/GitHelper.java
+++ b/syncronizer/src/org/sync/githelper/GitHelper.java
@@ -330,6 +330,7 @@ public class GitHelper extends RepositoryHelper {
       if(null == gitFastImport) {
         ProcessBuilder process = new ProcessBuilder();
         process.command(gitExecutable, "fast-import", "--done");
+        System.err.println("Writing to :" + repositoryDir);
         process.directory(new File(repositoryDir));
         try {
           gitFastImport = process.start();

--- a/syncronizer/src/org/sync/githelper/GitHelper.java
+++ b/syncronizer/src/org/sync/githelper/GitHelper.java
@@ -330,7 +330,6 @@ public class GitHelper extends RepositoryHelper {
       if(null == gitFastImport) {
         ProcessBuilder process = new ProcessBuilder();
         process.command(gitExecutable, "fast-import", "--done");
-        System.err.println("Writing to :" + repositoryDir);
         process.directory(new File(repositoryDir));
         try {
           gitFastImport = process.start();


### PR DESCRIPTION
We have been trying to use this utility (thanks very much it works really well, once we apply this edit) however we have been running it on Windows and have trouble with 
2021-02-22 19:07:13 fast-import:fatal: not a git repository (or any of the parent directories): .git
java.io.IOException: The pipe has been ended
        at java.io.FileOutputStream.writeBytes(Native Method)
        at java.io.FileOutputStream.write(Unknown Source)
        at java.io.BufferedOutputStream.write(Unknown 
        
 Which I believe is occuring due to the creation of the repository helper being prior to the configuration of the working folder location.
 
 Moving the creation to after the RepositoryHelperFactory.getFactory().setWorkingFolder(workingFolder); line fixes this for us in practice.