### PR TITLE
add dependency to pass "ant test"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ addons:
       - junit4
       - libhamcrest-java
       - ant
+      - ant-optional


### PR DESCRIPTION
"ant test" fails with:
/home/travis/build/planestraveler/git-starteam/build.xml:47: Problem: failed to create task or type junit
Cause: the class org.apache.tools.ant.taskdefs.optional.junit.JUnitTask was not found.
        This looks like one of Ant's optional components.
Action: Check that the appropriate optional JAR exists in
        -/usr/share/ant/lib
        -/home/travis/.ant/lib
        -a directory added on the command line with the -lib argument
adding ant-optional to allow junit task as suggested by 
https://stackoverflow.com/questions/6568634/how-to-solve-cause-the-class-org-apache-tools-ant-taskdefs-optional-junit-juni